### PR TITLE
Fix bug that GitHub Action for Qlty failed

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -3,10 +3,25 @@ on:
     branches:
       - main
 jobs:
-  call-workflow:
+  analyze:
     permissions:
       contents: read
       id-token: write
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-qlty.yml@main
-    with:
-      add-prefix: 'asyncffmpeg/'
+    runs-on: ubuntu-latest
+    steps:
+      - if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install ffmpeg
+      - if: matrix.os == 'windows-latest'
+        run: choco install ffmpeg
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.13'
+      - run: uv sync
+      - run: uv run invoke test.coverage --xml
+      - uses: qltysh/qlty-action/coverage@v2
+        with:
+          oidc: true
+          files: coverage.xml
+          format: cobertura
+          add-prefix: 'asyncffmpeg/'


### PR DESCRIPTION
This pull request updates the `.github/workflows/qlty.yml` workflow to run the quality checks directly within the repository, instead of calling a reusable workflow. The new workflow sets up the environment, installs dependencies, runs tests with coverage, and uploads the coverage report.

Workflow modernization and direct execution:

* Replaces the previous use of the external `reusable-qlty.yml` workflow with a new `analyze` job that executes all steps directly in the repository workflow (`.github/workflows/qlty.yml`).

Environment setup improvements:

* Adds steps to install `ffmpeg` on both Ubuntu and Windows runners, ensuring required dependencies are present for testing (`.github/workflows/qlty.yml`).
* Uses the `astral-sh/setup-uv` action to set up Python 3.13 and synchronize dependencies with `uv sync` (`.github/workflows/qlty.yml`).

Test execution and coverage reporting:

* Runs tests with coverage using `uv run invoke test.coverage --xml` and uploads the resulting coverage report with the `qltysh/qlty-action/coverage` action, specifying the coverage file and format (`.github/workflows/qlty.yml`).