### PR TITLE
Fix bug that GitHub Action for Qlty failed

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -9,10 +9,7 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     steps:
-      - if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install ffmpeg
-      - if: matrix.os == 'windows-latest'
-        run: choco install ffmpeg
+      - run: sudo apt install ffmpeg
       - uses: actions/checkout@v5
       - uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
This pull request simplifies the installation of `ffmpeg` in the GitHub Actions workflow by removing OS-specific conditional logic. Now, `ffmpeg` is always installed using `apt` regardless of the OS.

Workflow update:

* [`.github/workflows/qlty.yml`](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbL12-R12): Removed conditional steps for installing `ffmpeg` based on the operating system and now always installs it with `sudo apt install ffmpeg`.