### PR TITLE
Address new ruff warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
-FROM futureys/claude-code-python-development:20250915024000
+FROM futureys/claude-code-python-development:20251104123000
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
+    # To install ruamel-yaml-clib (the dependency of semgrep)
+    #   error: command 'cc' failed: No such file or directory
+    #   hint: This usually indicates a problem with the package or the build
+    #       environment.
+    #   help: `ruamel-yaml-clib` (v0.2.14) was included because `asyncffmpeg:dev`
+    #         (v1.3.0) depends on `semgrep` (v1.145.0) which depends on
+    #         `ruamel-yaml-clib`
+    build-essential \
  && rm -rf /var/lib/apt/lists/*
 COPY pyproject.toml /workspace
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/asyncffmpeg/exceptions.py
+++ b/asyncffmpeg/exceptions.py
@@ -14,5 +14,5 @@ class FFmpegProcessError(Error):
     """FFmpeg process failed."""
 
     def __init__(self, message: str, exit_code: int) -> None:
-        super().__init__(message)
+        super().__init__(message, exit_code)
         self.exit_code = exit_code

--- a/tests/test_ffmpeg_coroutine.py
+++ b/tests/test_ffmpeg_coroutine.py
@@ -25,7 +25,6 @@ from asyncffmpeg import FFmpegCoroutineFactory
 from asyncffmpeg import FFmpegProcessError
 from asyncffmpeg.ffmpegprocess.interface import FFmpegProcess
 from tests.testlibraries import SECOND_SLEEP_FOR_TEST_KEYBOARD_INTERRUPT_CTRL_C_POSIX
-from tests.testlibraries import SECOND_SLEEP_FOR_TEST_LONG
 from tests.testlibraries.create_stream_spec_croutine import CreateStreamSpecCoroutineCopy
 from tests.testlibraries.create_stream_spec_croutine import CreateStreamSpecCoroutineFilter
 from tests.testlibraries.example_use_case import example_use_case
@@ -141,7 +140,7 @@ class TestFFmpegCoroutine:
             CreateStreamSpecCoroutineFilter(path_file_input, path_file_output).create,
         )
         process_pool_executor_simulator.process.start()
-        await asyncio.sleep(SECOND_SLEEP_FOR_TEST_LONG)
+        await asyncio.sleep(SECOND_SLEEP_FOR_TEST_KEYBOARD_INTERRUPT_CTRL_C_POSIX)
         cls.simulate_ctrl_c_in_posix(process_pool_executor_simulator.process)
         process_pool_executor_simulator.process.join()
 


### PR DESCRIPTION
This pull request updates the build environment and improves error handling for FFmpeg processes, while also cleaning up test code. The main changes are grouped below by theme.

**Build Environment Updates:**

* Updated the base image in the `Dockerfile` to a newer version and added `build-essential` to the installation list to resolve issues with compiling dependencies such as `ruamel-yaml-clib` required by `semgrep`.

**Error Handling Improvements:**

* Modified the `FFmpegProcessError` class constructor to pass both `message` and `exit_code` to the base `Error` class, ensuring more informative error propagation.

**Test Code Maintenance:**

* Removed the unused import `SECOND_SLEEP_FOR_TEST_LONG` from `tests/test_ffmpeg_coroutine.py` for code cleanliness.
* Updated the sleep duration in the `keyboard_interrupt_sigint_for_coverage` coroutine to use `SECOND_SLEEP_FOR_TEST_KEYBOARD_INTERRUPT_CTRL_C_POSIX`, improving test accuracy for simulating keyboard interrupts.This pull request updates the build environment in the `Dockerfile` and refactors the test code in `tests/test_ffmpeg_coroutine.py` to improve maintainability and address dependency issues. The most important changes are grouped below:

Environment and Dependency Updates:

* Updated the base image in `Dockerfile` to a newer version (`futureys/claude-code-python-development:20251104123000`) and added `build-essential` to the installation list to support building dependencies like `ruamel-yaml-clib`, which is required by `semgrep`.

Test Code Refactoring:

* Removed the unused `SECOND_SLEEP_FOR_TEST_LONG` import from `tests/test_ffmpeg_coroutine.py` to clean up the code.
* Replaced the usage of `SECOND_SLEEP_FOR_TEST_LONG` with `SECOND_SLEEP_FOR_TEST_KEYBOARD_INTERRUPT_CTRL_C_POSIX` in the `keyboard_interrupt_sigint_for_coverage` coroutine to use a more appropriate constant for simulating keyboard interrupts in POSIX systems.